### PR TITLE
More workflow fixes. Needed Go

### DIFF
--- a/.github/workflows/python-lint.yml
+++ b/.github/workflows/python-lint.yml
@@ -3,11 +3,13 @@ on: [push]
 jobs:
   community-apps-python-lint:
     runs-on: ubuntu-latest
+    env:
+      PYTHON_VERSION: ""
     steps:
       - name: git clone
         uses: actions/checkout@v4
 
-      - name: set python version
+      - name: set Python version
         run: |
           export PYTHON_VERSION=$(yq '.language-support.python.version' workflow-configuration.yml)
           echo "This is the Python version => $PYTHON_VERSION"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,6 +38,8 @@ jobs:
       CONSOLE_URL: ${{ secrets.CONSOLE_URL }}
       MARKETPLACE_API_KEY: ${{ secrets.MARKETPLACE_API_KEY }}
       SSH_AUTH_SOCK: /tmp/ssh_agent.sock
+      GO_VERSION: ""
+      PYTHON_VERSION: ""
     permissions:
       id-token: write
       contents: write
@@ -63,10 +65,29 @@ jobs:
           git checkout ${{ github.ref_name }}
           git pull
 
-      - name: Set up Python
+      - name: set Python version
+        run: |
+          export PYTHON_VERSION=$(yq '.language-support.python.version' workflow-configuration.yml)
+          echo "This is the Python version => $PYTHON_VERSION"
+          echo "PYTHON_VERSION=${PYTHON_VERSION}" >> $GITHUB_ENV
+        working-directory: .nextmv/
+
+      - name: set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: "3.12"
+          python-version: ${{ env.PYTHON_VERSION }}
+
+      - name: set go version
+        run: |
+          export GO_VERSION=$(yq '.language-support.go.version' workflow-configuration.yml)
+          echo "This is the Go version => $GO_VERSION"
+          echo "GO_VERSION=${GO_VERSION}" >> $GITHUB_ENV
+        working-directory: .nextmv/
+
+      - name: set up go
+        uses: actions/setup-go@v5
+        with:
+          go-version: ${{ env.GO_VERSION }}
 
       - name: Install Python dependencies
         run: |

--- a/.nextmv/workflow-configuration.yml
+++ b/.nextmv/workflow-configuration.yml
@@ -97,7 +97,7 @@ language-support:
   go:
     version: 1.22
   python:
-    version: 3.12
+    version: 3.11
   java:
     version: 21
     distribution: temurin

--- a/.nextmv/workflow-configuration.yml
+++ b/.nextmv/workflow-configuration.yml
@@ -95,9 +95,9 @@ apps:
 # Main supported language versions.
 language-support:
   go:
-    version: 1.22.0
+    version: 1.22
   python:
-    version: 3.11
+    version: 3.12
   java:
     version: 21
     distribution: temurin


### PR DESCRIPTION
# Description

The release workflow needed native `go` to cross compile `nextroute`. Changes the Python step to use the language configured in the config file.