### PR TITLE
Update copyright dates in LICENSE files.

### DIFF
--- a/cost-flow-ortools/LICENSE
+++ b/cost-flow-ortools/LICENSE
@@ -186,7 +186,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright 2022-2023 nextmv.io inc.
+   Copyright 2022-2024 nextmv.io inc.
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/demand-forecasting-ortools/LICENSE
+++ b/demand-forecasting-ortools/LICENSE
@@ -186,7 +186,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright 2022-2023 nextmv.io inc.
+   Copyright 2022-2024 nextmv.io inc.
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/facility-location-ampl/LICENSE
+++ b/facility-location-ampl/LICENSE
@@ -186,7 +186,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright 2022-2023 nextmv.io inc.
+   Copyright 2022-2024 nextmv.io inc.
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/knapsack-ampl/LICENSE
+++ b/knapsack-ampl/LICENSE
@@ -186,7 +186,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright 2022-2023 nextmv.io inc.
+   Copyright 2022-2024 nextmv.io inc.
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/knapsack-gosdk/LICENSE
+++ b/knapsack-gosdk/LICENSE
@@ -186,7 +186,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright 2022-2023 nextmv.io inc.
+   Copyright 2022-2024 nextmv.io inc.
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/knapsack-gurobi/LICENSE
+++ b/knapsack-gurobi/LICENSE
@@ -186,7 +186,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright 2022-2023 nextmv.io inc.
+   Copyright 2022-2024 nextmv.io inc.
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/knapsack-java-ortools/LICENSE
+++ b/knapsack-java-ortools/LICENSE
@@ -186,7 +186,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright 2022-2023 nextmv.io inc.
+   Copyright 2022-2024 nextmv.io inc.
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/knapsack-ortools-csv/LICENSE
+++ b/knapsack-ortools-csv/LICENSE
@@ -186,7 +186,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright 2022-2023 nextmv.io inc.
+   Copyright 2022-2024 nextmv.io inc.
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/knapsack-ortools/LICENSE
+++ b/knapsack-ortools/LICENSE
@@ -186,7 +186,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright 2022-2023 nextmv.io inc.
+   Copyright 2022-2024 nextmv.io inc.
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/knapsack-pyomo/LICENSE
+++ b/knapsack-pyomo/LICENSE
@@ -186,7 +186,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright 2022-2023 nextmv.io inc.
+   Copyright 2022-2024 nextmv.io inc.
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/nextroute/LICENSE
+++ b/nextroute/LICENSE
@@ -186,7 +186,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright 2022-2023 nextmv.io inc.
+   Copyright 2022-2024 nextmv.io inc.
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/order-fulfillment-gosdk/LICENSE
+++ b/order-fulfillment-gosdk/LICENSE
@@ -186,7 +186,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright 2022-2023 nextmv.io inc.
+   Copyright 2022-2024 nextmv.io inc.
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/price-optimization-ampl/LICENSE
+++ b/price-optimization-ampl/LICENSE
@@ -186,7 +186,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright 2022-2023 nextmv.io inc.
+   Copyright 2022-2024 nextmv.io inc.
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/routing-java-ortools/LICENSE
+++ b/routing-java-ortools/LICENSE
@@ -186,7 +186,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright 2022-2023 nextmv.io inc.
+   Copyright 2022-2024 nextmv.io inc.
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/routing-ortools/LICENSE
+++ b/routing-ortools/LICENSE
@@ -186,7 +186,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright 2022-2023 nextmv.io inc.
+   Copyright 2022-2024 nextmv.io inc.
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/shift-assignment-ortools/LICENSE
+++ b/shift-assignment-ortools/LICENSE
@@ -186,7 +186,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright 2022-2023 nextmv.io inc.
+   Copyright 2022-2024 nextmv.io inc.
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/shift-assignment-pyomo/LICENSE
+++ b/shift-assignment-pyomo/LICENSE
@@ -186,7 +186,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright 2022-2023 nextmv.io inc.
+   Copyright 2022-2024 nextmv.io inc.
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/shift-planning-ortools/LICENSE
+++ b/shift-planning-ortools/LICENSE
@@ -186,7 +186,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright 2022-2023 nextmv.io inc.
+   Copyright 2022-2024 nextmv.io inc.
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/shift-planning-pyomo/LICENSE
+++ b/shift-planning-pyomo/LICENSE
@@ -186,7 +186,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright 2022-2023 nextmv.io inc.
+   Copyright 2022-2024 nextmv.io inc.
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/shift-scheduling-gosdk/LICENSE
+++ b/shift-scheduling-gosdk/LICENSE
@@ -186,7 +186,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright 2022-2023 nextmv.io inc.
+   Copyright 2022-2024 nextmv.io inc.
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/xpress/LICENSE
+++ b/xpress/LICENSE
@@ -186,7 +186,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright 2022-2023 nextmv.io inc.
+   Copyright 2022-2024 nextmv.io inc.
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.


### PR DESCRIPTION
This changes all `LICENSE` files to replace 2023 with 2024.

I confirmed that there are 21 `LICENSE` files in the repository, and there are 21 `LICENSE` files changed in this PR.

```zsh
community-apps % find . -name LICENSE | wc -l
      21
```