### PR TITLE
Aligns docker test snippets and fixes pyomo runtime dependency

### DIFF
--- a/.nextmv/readme/cost-flow-ortools/2.sh
+++ b/.nextmv/readme/cost-flow-ortools/2.sh
@@ -1,3 +1,3 @@
 cat input.json | docker run -i --rm \
 -v $(pwd):/app ghcr.io/nextmv-io/runtime/python:3.11 \
-sh -c 'pip install -r requirements.txt && python3 /app/main.py'
+sh -c 'pip install -r requirements.txt > /dev/null && python3 /app/main.py'

--- a/.nextmv/readme/cost-flow-ortools/2.sh
+++ b/.nextmv/readme/cost-flow-ortools/2.sh
@@ -1,3 +1,3 @@
 cat input.json | docker run -i --rm \
--v $(pwd):/app ghcr.io/nextmv-io/runtime/ortools:latest \
-python3 /app/main.py
+-v $(pwd):/app ghcr.io/nextmv-io/runtime/python:3.11 \
+sh -c 'pip install -r requirements.txt && python3 /app/main.py'

--- a/.nextmv/readme/demand-forecasting-ortools/2.sh
+++ b/.nextmv/readme/demand-forecasting-ortools/2.sh
@@ -1,3 +1,3 @@
 cat input.json | docker run -i --rm \
 -v $(pwd):/app ghcr.io/nextmv-io/runtime/python:3.11 \
-sh -c 'pip install -r requirements.txt && python3 /app/main.py'
+sh -c 'pip install -r requirements.txt > /dev/null && python3 /app/main.py'

--- a/.nextmv/readme/demand-forecasting-ortools/2.sh
+++ b/.nextmv/readme/demand-forecasting-ortools/2.sh
@@ -1,3 +1,3 @@
 cat input.json | docker run -i --rm \
--v $(pwd):/app ghcr.io/nextmv-io/runtime/ortools:latest \
-python3 /app/main.py
+-v $(pwd):/app ghcr.io/nextmv-io/runtime/python:3.11 \
+sh -c 'pip install -r requirements.txt && python3 /app/main.py'

--- a/.nextmv/readme/facility-location-ampl/2.sh
+++ b/.nextmv/readme/facility-location-ampl/2.sh
@@ -1,3 +1,3 @@
 cat input.json | docker run -i --rm \
 -v $(pwd):/app ghcr.io/nextmv-io/runtime/python:3.11 \
-sh -c 'pip install -r requirements.txt && python3 /app/main.py'
+sh -c 'pip install -r requirements.txt > /dev/null && python3 /app/main.py'

--- a/.nextmv/readme/facility-location-ampl/2.sh
+++ b/.nextmv/readme/facility-location-ampl/2.sh
@@ -1,3 +1,3 @@
 cat input.json | docker run -i --rm \
--v $(pwd):/app ghcr.io/nextmv-io/runtime/ampl:latest \
-python3 /app/main.py
+-v $(pwd):/app ghcr.io/nextmv-io/runtime/python:3.11 \
+sh -c 'pip install -r requirements.txt && python3 /app/main.py'

--- a/.nextmv/readme/knapsack-ampl/2.sh
+++ b/.nextmv/readme/knapsack-ampl/2.sh
@@ -1,3 +1,3 @@
 cat input.json | docker run -i --rm \
 -v $(pwd):/app ghcr.io/nextmv-io/runtime/python:3.11 \
-sh -c 'pip install -r requirements.txt && python3 /app/main.py'
+sh -c 'pip install -r requirements.txt > /dev/null && python3 /app/main.py'

--- a/.nextmv/readme/knapsack-ampl/2.sh
+++ b/.nextmv/readme/knapsack-ampl/2.sh
@@ -1,3 +1,3 @@
 cat input.json | docker run -i --rm \
--v $(pwd):/app ghcr.io/nextmv-io/runtime/ampl:latest \
-python3 /app/main.py
+-v $(pwd):/app ghcr.io/nextmv-io/runtime/python:3.11 \
+sh -c 'pip install -r requirements.txt && python3 /app/main.py'

--- a/.nextmv/readme/knapsack-gurobi/2.sh
+++ b/.nextmv/readme/knapsack-gurobi/2.sh
@@ -1,3 +1,3 @@
 cat input.json | docker run -i --rm \
 -v $(pwd):/app ghcr.io/nextmv-io/runtime/python:3.11 \
-sh -c 'pip install -r requirements.txt && python3 /app/main.py'
+sh -c 'pip install -r requirements.txt > /dev/null && python3 /app/main.py'

--- a/.nextmv/readme/knapsack-gurobi/2.sh
+++ b/.nextmv/readme/knapsack-gurobi/2.sh
@@ -1,3 +1,3 @@
 cat input.json | docker run -i --rm \
--v $(pwd):/app ghcr.io/nextmv-io/runtime/gurobi:latest \
-python3 /app/main.py
+-v $(pwd):/app ghcr.io/nextmv-io/runtime/python:3.11 \
+sh -c 'pip install -r requirements.txt && python3 /app/main.py'

--- a/.nextmv/readme/knapsack-ortools-csv/2.sh
+++ b/.nextmv/readme/knapsack-ortools-csv/2.sh
@@ -1,3 +1,3 @@
 docker run -i --rm \
 -v $(pwd):/app ghcr.io/nextmv-io/runtime/python:3.11 \
-sh -c 'pip install -r requirements.txt && python3 /app/main.py'
+sh -c 'pip install -r requirements.txt > /dev/null && python3 /app/main.py'

--- a/.nextmv/readme/knapsack-ortools-csv/2.sh
+++ b/.nextmv/readme/knapsack-ortools-csv/2.sh
@@ -1,3 +1,3 @@
 docker run -i --rm \
--v $(pwd):/app ghcr.io/nextmv-io/runtime/ortools:latest \
-python3 /app/main.py
+-v $(pwd):/app ghcr.io/nextmv-io/runtime/python:3.11 \
+sh -c 'pip install -r requirements.txt && python3 /app/main.py'

--- a/.nextmv/readme/knapsack-ortools/2.sh
+++ b/.nextmv/readme/knapsack-ortools/2.sh
@@ -1,3 +1,3 @@
 cat inputs/input.json | docker run -i --rm \
 -v $(pwd):/app ghcr.io/nextmv-io/runtime/python:3.11 \
-sh -c 'pip install -r requirements.txt && python3 /app/main.py'
+sh -c 'pip install -r requirements.txt > /dev/null && python3 /app/main.py'

--- a/.nextmv/readme/knapsack-ortools/2.sh
+++ b/.nextmv/readme/knapsack-ortools/2.sh
@@ -1,3 +1,3 @@
-cat input.json | docker run -i --rm \
--v $(pwd):/app ghcr.io/nextmv-io/runtime/ortools:latest \
-python3 /app/main.py
+cat inputs/input.json | docker run -i --rm \
+-v $(pwd):/app ghcr.io/nextmv-io/runtime/python:3.11 \
+sh -c 'pip install -r requirements.txt && python3 /app/main.py'

--- a/.nextmv/readme/knapsack-pyomo/2.sh
+++ b/.nextmv/readme/knapsack-pyomo/2.sh
@@ -1,3 +1,3 @@
 cat input.json | docker run -i --rm \
 -v $(pwd):/app ghcr.io/nextmv-io/runtime/pyomo:latest \
-python3 /app/main.py
+sh -c 'python3 /app/main.py'

--- a/.nextmv/readme/price-optimization-ampl/2.sh
+++ b/.nextmv/readme/price-optimization-ampl/2.sh
@@ -1,3 +1,3 @@
 cat input.json | docker run -i --rm \
 -v $(pwd):/app ghcr.io/nextmv-io/runtime/python:3.11 \
-sh -c 'pip install -r requirements.txt && python3 /app/main.py'
+sh -c 'pip install -r requirements.txt > /dev/null && python3 /app/main.py'

--- a/.nextmv/readme/price-optimization-ampl/2.sh
+++ b/.nextmv/readme/price-optimization-ampl/2.sh
@@ -1,3 +1,3 @@
 cat input.json | docker run -i --rm \
--v $(pwd):/app ghcr.io/nextmv-io/runtime/ampl:latest \
-python3 /app/main.py
+-v $(pwd):/app ghcr.io/nextmv-io/runtime/python:3.11 \
+sh -c 'pip install -r requirements.txt && python3 /app/main.py'

--- a/.nextmv/readme/routing-ortools/2.sh
+++ b/.nextmv/readme/routing-ortools/2.sh
@@ -1,3 +1,3 @@
 cat input.json | docker run -i --rm \
 -v $(pwd):/app ghcr.io/nextmv-io/runtime/python:3.11 \
-sh -c 'pip install -r requirements.txt && python3 /app/main.py'
+sh -c 'pip install -r requirements.txt > /dev/null && python3 /app/main.py'

--- a/.nextmv/readme/routing-ortools/2.sh
+++ b/.nextmv/readme/routing-ortools/2.sh
@@ -1,3 +1,3 @@
 cat input.json | docker run -i --rm \
--v $(pwd):/app ghcr.io/nextmv-io/runtime/ortools:latest \
-python3 /app/main.py
+-v $(pwd):/app ghcr.io/nextmv-io/runtime/python:3.11 \
+sh -c 'pip install -r requirements.txt && python3 /app/main.py'

--- a/.nextmv/readme/shift-assignment-ortools/2.sh
+++ b/.nextmv/readme/shift-assignment-ortools/2.sh
@@ -1,3 +1,3 @@
 cat input.json | docker run -i --rm \
 -v $(pwd):/app ghcr.io/nextmv-io/runtime/python:3.11 \
-sh -c 'pip install -r requirements.txt && python3 /app/main.py'
+sh -c 'pip install -r requirements.txt > /dev/null && python3 /app/main.py'

--- a/.nextmv/readme/shift-assignment-ortools/2.sh
+++ b/.nextmv/readme/shift-assignment-ortools/2.sh
@@ -1,3 +1,3 @@
 cat input.json | docker run -i --rm \
--v $(pwd):/app ghcr.io/nextmv-io/runtime/ortools:latest \
-python3 /app/main.py
+-v $(pwd):/app ghcr.io/nextmv-io/runtime/python:3.11 \
+sh -c 'pip install -r requirements.txt && python3 /app/main.py'

--- a/.nextmv/readme/shift-assignment-pyomo/2.sh
+++ b/.nextmv/readme/shift-assignment-pyomo/2.sh
@@ -1,3 +1,3 @@
 cat input.json | docker run -i --rm \
 -v $(pwd):/app ghcr.io/nextmv-io/runtime/pyomo:latest \
-python3 /app/main.py
+sh -c 'python3 /app/main.py'

--- a/.nextmv/readme/shift-planning-ortools/2.sh
+++ b/.nextmv/readme/shift-planning-ortools/2.sh
@@ -1,3 +1,3 @@
 cat input.json | docker run -i --rm \
 -v $(pwd):/app ghcr.io/nextmv-io/runtime/python:3.11 \
-sh -c 'pip install -r requirements.txt && python3 /app/main.py'
+sh -c 'pip install -r requirements.txt > /dev/null && python3 /app/main.py'

--- a/.nextmv/readme/shift-planning-ortools/2.sh
+++ b/.nextmv/readme/shift-planning-ortools/2.sh
@@ -1,3 +1,3 @@
 cat input.json | docker run -i --rm \
--v $(pwd):/app ghcr.io/nextmv-io/runtime/ortools:latest \
-python3 /app/main.py
+-v $(pwd):/app ghcr.io/nextmv-io/runtime/python:3.11 \
+sh -c 'pip install -r requirements.txt && python3 /app/main.py'

--- a/.nextmv/readme/shift-planning-pyomo/2.sh
+++ b/.nextmv/readme/shift-planning-pyomo/2.sh
@@ -1,3 +1,3 @@
 cat input.json | docker run -i --rm \
 -v $(pwd):/app ghcr.io/nextmv-io/runtime/pyomo:latest \
-python3 /app/main.py
+sh -c 'python3 /app/main.py'

--- a/.nextmv/readme/xpress/2.sh
+++ b/.nextmv/readme/xpress/2.sh
@@ -1,3 +1,3 @@
 cat input.json | docker run -i --rm \
 -v $(pwd):/app ghcr.io/nextmv-io/runtime/python:3.11 \
-sh -c 'pip install -r requirements.txt && python3 /app/main.py'
+sh -c 'pip install -r requirements.txt > /dev/null && python3 /app/main.py'

--- a/.nextmv/readme/xpress/2.sh
+++ b/.nextmv/readme/xpress/2.sh
@@ -1,3 +1,3 @@
 cat input.json | docker run -i --rm \
--v $(pwd):/app ghcr.io/nextmv-io/runtime/xpress:latest \
-python3 /app/main.py
+-v $(pwd):/app ghcr.io/nextmv-io/runtime/python:3.11 \
+sh -c 'pip install -r requirements.txt && python3 /app/main.py'

--- a/cost-flow-ortools/README.md
+++ b/cost-flow-ortools/README.md
@@ -60,8 +60,8 @@ Nextmv Cloud, you can use the following command:
 
 ```bash
 cat input.json | docker run -i --rm \
--v $(pwd):/app ghcr.io/nextmv-io/runtime/ortools:latest \
-python3 /app/main.py
+-v $(pwd):/app ghcr.io/nextmv-io/runtime/python:3.11 \
+sh -c 'pip install -r requirements.txt && python3 /app/main.py'
 ```
 
 You can also debug the application by running it in a Dev Container. This

--- a/cost-flow-ortools/README.md
+++ b/cost-flow-ortools/README.md
@@ -61,7 +61,7 @@ Nextmv Cloud, you can use the following command:
 ```bash
 cat input.json | docker run -i --rm \
 -v $(pwd):/app ghcr.io/nextmv-io/runtime/python:3.11 \
-sh -c 'pip install -r requirements.txt && python3 /app/main.py'
+sh -c 'pip install -r requirements.txt > /dev/null && python3 /app/main.py'
 ```
 
 You can also debug the application by running it in a Dev Container. This

--- a/cost-flow-ortools/README.md
+++ b/cost-flow-ortools/README.md
@@ -33,10 +33,9 @@ The most important files created are `main.py` and `input.json`.
 
 Follow these steps to run locally.
 
-1. The packages listed in the `requirements.txt` file are available when using
-   the runtime specified in the `app.yaml` manifest. This runtime is used when
-   making remote runs. When working locally, make sure that all the required
-   packages are installed:
+1. The packages listed in the `requirements.txt` will get bundled with the app
+   as defined in the `app.yaml` manifest. When working locally, make sure that
+   these are installed as well:
 
     ```bash
     pip3 install -r requirements.txt

--- a/demand-forecasting-ortools/README.md
+++ b/demand-forecasting-ortools/README.md
@@ -41,8 +41,8 @@ Nextmv Cloud, you can use the following command:
 
 ```bash
 cat input.json | docker run -i --rm \
--v $(pwd):/app ghcr.io/nextmv-io/runtime/ortools:latest \
-python3 /app/main.py
+-v $(pwd):/app ghcr.io/nextmv-io/runtime/python:3.11 \
+sh -c 'pip install -r requirements.txt && python3 /app/main.py'
 ```
 
 You can also debug the application by running it in a Dev Container. This

--- a/demand-forecasting-ortools/README.md
+++ b/demand-forecasting-ortools/README.md
@@ -42,7 +42,7 @@ Nextmv Cloud, you can use the following command:
 ```bash
 cat input.json | docker run -i --rm \
 -v $(pwd):/app ghcr.io/nextmv-io/runtime/python:3.11 \
-sh -c 'pip install -r requirements.txt && python3 /app/main.py'
+sh -c 'pip install -r requirements.txt > /dev/null && python3 /app/main.py'
 ```
 
 You can also debug the application by running it in a Dev Container. This

--- a/demand-forecasting-ortools/README.md
+++ b/demand-forecasting-ortools/README.md
@@ -14,10 +14,9 @@ The most important files created are `main.py` and `input.json`.
 
 Follow these steps to run locally.
 
-1. The packages listed in the `requirements.txt` file are available when using
-   the runtime specified in the `app.yaml` manifest. This runtime is used when
-   making remote runs. When working locally, make sure that all the required
-   packages are installed:
+1. The packages listed in the `requirements.txt` will get bundled with the app
+   as defined in the `app.yaml` manifest. When working locally, make sure that
+   these are installed as well:
 
     ```bash
     pip3 install -r requirements.txt

--- a/facility-location-ampl/README.md
+++ b/facility-location-ampl/README.md
@@ -83,8 +83,8 @@ Nextmv Cloud, you can use the following command:
 
 ```bash
 cat input.json | docker run -i --rm \
--v $(pwd):/app ghcr.io/nextmv-io/runtime/ampl:latest \
-python3 /app/main.py
+-v $(pwd):/app ghcr.io/nextmv-io/runtime/python:3.11 \
+sh -c 'pip install -r requirements.txt && python3 /app/main.py'
 ```
 
 You can also debug the application by running it in a Dev Container. This

--- a/facility-location-ampl/README.md
+++ b/facility-location-ampl/README.md
@@ -84,7 +84,7 @@ Nextmv Cloud, you can use the following command:
 ```bash
 cat input.json | docker run -i --rm \
 -v $(pwd):/app ghcr.io/nextmv-io/runtime/python:3.11 \
-sh -c 'pip install -r requirements.txt && python3 /app/main.py'
+sh -c 'pip install -r requirements.txt > /dev/null && python3 /app/main.py'
 ```
 
 You can also debug the application by running it in a Dev Container. This

--- a/facility-location-ampl/README.md
+++ b/facility-location-ampl/README.md
@@ -55,10 +55,9 @@ The most important files created are `main.py`, `floc_bend.mod`,
 
 Follow these steps to run locally.
 
-1. The packages listed in the `requirements.txt` file are available when using
-   the runtime specified in the `app.yaml` manifest. This runtime is used when
-   making remote runs. When working locally, make sure that all the required
-   packages are installed:
+1. The packages listed in the `requirements.txt` will get bundled with the app
+   as defined in the `app.yaml` manifest. When working locally, make sure that
+   these are installed as well:
 
     ```bash
     pip3 install -r requirements.txt

--- a/knapsack-ampl/README.md
+++ b/knapsack-ampl/README.md
@@ -32,10 +32,9 @@ The most important files created are `main.py`, `input.json`, and
 
 Follow these steps to run locally.
 
-1. The packages listed in the `requirements.txt` file are available when using
-   the runtime specified in the `app.yaml` manifest. This runtime is used when
-   making remote runs. When working locally, make sure that all the required
-   packages are installed:
+1. The packages listed in the `requirements.txt` will get bundled with the app
+   as defined in the `app.yaml` manifest. When working locally, make sure that
+   these are installed as well:
 
     ```bash
     pip3 install -r requirements.txt

--- a/knapsack-ampl/README.md
+++ b/knapsack-ampl/README.md
@@ -61,7 +61,7 @@ Nextmv Cloud, you can use the following command:
 ```bash
 cat input.json | docker run -i --rm \
 -v $(pwd):/app ghcr.io/nextmv-io/runtime/python:3.11 \
-sh -c 'pip install -r requirements.txt && python3 /app/main.py'
+sh -c 'pip install -r requirements.txt > /dev/null && python3 /app/main.py'
 ```
 
 You can also debug the application by running it in a Dev Container. This

--- a/knapsack-ampl/README.md
+++ b/knapsack-ampl/README.md
@@ -60,8 +60,8 @@ Nextmv Cloud, you can use the following command:
 
 ```bash
 cat input.json | docker run -i --rm \
--v $(pwd):/app ghcr.io/nextmv-io/runtime/ampl:latest \
-python3 /app/main.py
+-v $(pwd):/app ghcr.io/nextmv-io/runtime/python:3.11 \
+sh -c 'pip install -r requirements.txt && python3 /app/main.py'
 ```
 
 You can also debug the application by running it in a Dev Container. This

--- a/knapsack-gurobi/README.md
+++ b/knapsack-gurobi/README.md
@@ -53,7 +53,7 @@ Nextmv Cloud, you can use the following command:
 ```bash
 cat input.json | docker run -i --rm \
 -v $(pwd):/app ghcr.io/nextmv-io/runtime/python:3.11 \
-sh -c 'pip install -r requirements.txt && python3 /app/main.py'
+sh -c 'pip install -r requirements.txt > /dev/null && python3 /app/main.py'
 ```
 
 You can also debug the application by running it in a Dev Container. This

--- a/knapsack-gurobi/README.md
+++ b/knapsack-gurobi/README.md
@@ -52,8 +52,8 @@ Nextmv Cloud, you can use the following command:
 
 ```bash
 cat input.json | docker run -i --rm \
--v $(pwd):/app ghcr.io/nextmv-io/runtime/gurobi:latest \
-python3 /app/main.py
+-v $(pwd):/app ghcr.io/nextmv-io/runtime/python:3.11 \
+sh -c 'pip install -r requirements.txt && python3 /app/main.py'
 ```
 
 You can also debug the application by running it in a Dev Container. This

--- a/knapsack-gurobi/README.md
+++ b/knapsack-gurobi/README.md
@@ -25,10 +25,9 @@ The most important files created are `main.py`, `input.json`, and
 
 Follow these steps to run locally.
 
-1. The packages listed in the `requirements.txt` file are available when using
-   the runtime specified in the `app.yaml` manifest. This runtime is used when
-   making remote runs. When working locally, make sure that all the required
-   packages are installed:
+1. The packages listed in the `requirements.txt` will get bundled with the app
+   as defined in the `app.yaml` manifest. When working locally, make sure that
+   these are installed as well:
 
     ```bash
     pip3 install -r requirements.txt

--- a/knapsack-ortools-csv/README.md
+++ b/knapsack-ortools-csv/README.md
@@ -54,8 +54,8 @@ Nextmv Cloud, you can use the following command:
 
 ```bash
 docker run -i --rm \
--v $(pwd):/app ghcr.io/nextmv-io/runtime/ortools:latest \
-python3 /app/main.py
+-v $(pwd):/app ghcr.io/nextmv-io/runtime/python:3.11 \
+sh -c 'pip install -r requirements.txt && python3 /app/main.py'
 ```
 
 You can also debug the application by running it in a Dev Container. This

--- a/knapsack-ortools-csv/README.md
+++ b/knapsack-ortools-csv/README.md
@@ -55,7 +55,7 @@ Nextmv Cloud, you can use the following command:
 ```bash
 docker run -i --rm \
 -v $(pwd):/app ghcr.io/nextmv-io/runtime/python:3.11 \
-sh -c 'pip install -r requirements.txt && python3 /app/main.py'
+sh -c 'pip install -r requirements.txt > /dev/null && python3 /app/main.py'
 ```
 
 You can also debug the application by running it in a Dev Container. This

--- a/knapsack-ortools-csv/README.md
+++ b/knapsack-ortools-csv/README.md
@@ -27,10 +27,9 @@ work with Nextmv Cloud and fulfills these requirements:
 
 Follow these steps to run locally.
 
-1. The packages listed in the `requirements.txt` file are available when using
-   the runtime specified in the `app.yaml` manifest. This runtime is used when
-   making remote runs. When working locally, make sure that all the required
-   packages are installed:
+1. The packages listed in the `requirements.txt` will get bundled with the app
+   as defined in the `app.yaml` manifest. When working locally, make sure that
+   these are installed as well:
 
     ```bash
     pip3 install -r requirements.txt

--- a/knapsack-ortools/README.md
+++ b/knapsack-ortools/README.md
@@ -48,9 +48,9 @@ To run the application locally in the same docker image as the one used on the
 Nextmv Cloud, you can use the following command:
 
 ```bash
-cat input.json | docker run -i --rm \
--v $(pwd):/app ghcr.io/nextmv-io/runtime/ortools:latest \
-python3 /app/main.py
+cat inputs/input.json | docker run -i --rm \
+-v $(pwd):/app ghcr.io/nextmv-io/runtime/python:3.11 \
+sh -c 'pip install -r requirements.txt && python3 /app/main.py'
 ```
 
 You can also debug the application by running it in a Dev Container. This

--- a/knapsack-ortools/README.md
+++ b/knapsack-ortools/README.md
@@ -22,10 +22,9 @@ The most important files created are `main.py` and `input.json`.
 
 Follow these steps to run locally.
 
-1. The packages listed in the `requirements.txt` file are available when using
-   the runtime specified in the `app.yaml` manifest. This runtime is used when
-   making remote runs. When working locally, make sure that all the required
-   packages are installed:
+1. The packages listed in the `requirements.txt` will get bundled with the app
+   as defined in the `app.yaml` manifest. When working locally, make sure that
+   these are installed as well:
 
     ```bash
     pip3 install -r requirements.txt

--- a/knapsack-ortools/README.md
+++ b/knapsack-ortools/README.md
@@ -50,7 +50,7 @@ Nextmv Cloud, you can use the following command:
 ```bash
 cat inputs/input.json | docker run -i --rm \
 -v $(pwd):/app ghcr.io/nextmv-io/runtime/python:3.11 \
-sh -c 'pip install -r requirements.txt && python3 /app/main.py'
+sh -c 'pip install -r requirements.txt > /dev/null && python3 /app/main.py'
 ```
 
 You can also debug the application by running it in a Dev Container. This

--- a/knapsack-pyomo/README.md
+++ b/knapsack-pyomo/README.md
@@ -30,6 +30,9 @@ Follow these steps to run locally.
     pip3 install -r requirements.txt
     ```
 
+1. Further dependencies can be specified in the `requirements_extra.txt` file.
+   These dependencies will get bundled with the app on push.
+
 1. Pyomo [does not include any solvers][pyomo-solvers]. This template assumes
    that supported providers are [`glpk`][glpk] and [`cbc`][cbc]. Make sure you
    have installed them locally, as they are already installed on the image when

--- a/knapsack-pyomo/README.md
+++ b/knapsack-pyomo/README.md
@@ -56,7 +56,7 @@ Nextmv Cloud, you can use the following command:
 ```bash
 cat input.json | docker run -i --rm \
 -v $(pwd):/app ghcr.io/nextmv-io/runtime/pyomo:latest \
-python3 /app/main.py
+sh -c 'python3 /app/main.py'
 ```
 
 You can also debug the application by running it in a Dev Container. This

--- a/knapsack-pyomo/app.yaml
+++ b/knapsack-pyomo/app.yaml
@@ -5,3 +5,7 @@ runtime: ghcr.io/nextmv-io/runtime/pyomo:latest
 # (e.g.: configs/*.json) is supported.
 files:
   - main.py
+python:
+  # Packages the app depends on need to be listed in a requirements_extra.txt file
+  # that is referenced here. All listed packages will get bundled with the app.
+  pip-requirements: requirements_extra.txt

--- a/knapsack-pyomo/app.yaml
+++ b/knapsack-pyomo/app.yaml
@@ -1,11 +1,7 @@
 # This manifest holds the information the app needs to run on the Nextmv Cloud.
 type: python
-runtime: ghcr.io/nextmv-io/runtime/python:3.11
+runtime: ghcr.io/nextmv-io/runtime/pyomo:latest
 # List all files/directories that should be included in the app. Globbing
 # (e.g.: configs/*.json) is supported.
 files:
   - main.py
-python:
-  # Packages the app depends on need to be listed in a requirements.txt file
-  # that is referenced here. All listed packages will get bundled with the app.
-  pip-requirements: requirements.txt

--- a/knapsack-pyomo/requirements_extra.txt
+++ b/knapsack-pyomo/requirements_extra.txt
@@ -1,0 +1,4 @@
+# Extra requirements that will be bundled with the app.
+# These are in addition to the ones already installed in
+# the runtime image (the ones in the requirements.txt file).
+# sample-dependency==0.1.0

--- a/price-optimization-ampl/README.md
+++ b/price-optimization-ampl/README.md
@@ -71,7 +71,7 @@ Nextmv Cloud, you can use the following command:
 ```bash
 cat input.json | docker run -i --rm \
 -v $(pwd):/app ghcr.io/nextmv-io/runtime/python:3.11 \
-sh -c 'pip install -r requirements.txt && python3 /app/main.py'
+sh -c 'pip install -r requirements.txt > /dev/null && python3 /app/main.py'
 ```
 
 You can also debug the application by running it in a Dev Container. This

--- a/price-optimization-ampl/README.md
+++ b/price-optimization-ampl/README.md
@@ -70,8 +70,8 @@ Nextmv Cloud, you can use the following command:
 
 ```bash
 cat input.json | docker run -i --rm \
--v $(pwd):/app ghcr.io/nextmv-io/runtime/ampl:latest \
-python3 /app/main.py
+-v $(pwd):/app ghcr.io/nextmv-io/runtime/python:3.11 \
+sh -c 'pip install -r requirements.txt && python3 /app/main.py'
 ```
 
 You can also debug the application by running it in a Dev Container. This

--- a/price-optimization-ampl/README.md
+++ b/price-optimization-ampl/README.md
@@ -42,10 +42,9 @@ and `ampl_license_uuid.template`.
 
 Follow these steps to run locally.
 
-1. The packages listed in the `requirements.txt` file are available when using
-   the runtime specified in the `app.yaml` manifest. This runtime is used when
-   making remote runs. When working locally, make sure that all the required
-   packages are installed:
+1. The packages listed in the `requirements.txt` will get bundled with the app
+   as defined in the `app.yaml` manifest. When working locally, make sure that
+   these are installed as well:
 
     ```bash
     pip3 install -r requirements.txt

--- a/routing-ortools/README.md
+++ b/routing-ortools/README.md
@@ -13,10 +13,9 @@ The most important files created are `main.py` and `input.json`.
 
 Follow these steps to run locally.
 
-1. The packages listed in the `requirements.txt` file are available when using
-   the runtime specified in the `app.yaml` manifest. This runtime is used when
-   making remote runs. When working locally, make sure that all the required
-   packages are installed:
+1. The packages listed in the `requirements.txt` will get bundled with the app
+   as defined in the `app.yaml` manifest. When working locally, make sure that
+   these are installed as well:
 
     ```bash
     pip3 install -r requirements.txt

--- a/routing-ortools/README.md
+++ b/routing-ortools/README.md
@@ -41,7 +41,7 @@ Nextmv Cloud, you can use the following command:
 ```bash
 cat input.json | docker run -i --rm \
 -v $(pwd):/app ghcr.io/nextmv-io/runtime/python:3.11 \
-sh -c 'pip install -r requirements.txt && python3 /app/main.py'
+sh -c 'pip install -r requirements.txt > /dev/null && python3 /app/main.py'
 ```
 
 You can also debug the application by running it in a Dev Container. This

--- a/routing-ortools/README.md
+++ b/routing-ortools/README.md
@@ -40,8 +40,8 @@ Nextmv Cloud, you can use the following command:
 
 ```bash
 cat input.json | docker run -i --rm \
--v $(pwd):/app ghcr.io/nextmv-io/runtime/ortools:latest \
-python3 /app/main.py
+-v $(pwd):/app ghcr.io/nextmv-io/runtime/python:3.11 \
+sh -c 'pip install -r requirements.txt && python3 /app/main.py'
 ```
 
 You can also debug the application by running it in a Dev Container. This

--- a/shift-assignment-ortools/README.md
+++ b/shift-assignment-ortools/README.md
@@ -13,10 +13,9 @@ The most important files created are `main.py` and `input.json`.
 
 Follow these steps to run locally.
 
-1. The packages listed in the `requirements.txt` file are available when using
-   the runtime specified in the `app.yaml` manifest. This runtime is used when
-   making remote runs. When working locally, make sure that all the required
-   packages are installed:
+1. The packages listed in the `requirements.txt` will get bundled with the app
+   as defined in the `app.yaml` manifest. When working locally, make sure that
+   these are installed as well:
 
     ```bash
     pip3 install -r requirements.txt

--- a/shift-assignment-ortools/README.md
+++ b/shift-assignment-ortools/README.md
@@ -41,7 +41,7 @@ Nextmv Cloud, you can use the following command:
 ```bash
 cat input.json | docker run -i --rm \
 -v $(pwd):/app ghcr.io/nextmv-io/runtime/python:3.11 \
-sh -c 'pip install -r requirements.txt && python3 /app/main.py'
+sh -c 'pip install -r requirements.txt > /dev/null && python3 /app/main.py'
 ```
 
 You can also debug the application by running it in a Dev Container. This

--- a/shift-assignment-ortools/README.md
+++ b/shift-assignment-ortools/README.md
@@ -40,8 +40,8 @@ Nextmv Cloud, you can use the following command:
 
 ```bash
 cat input.json | docker run -i --rm \
--v $(pwd):/app ghcr.io/nextmv-io/runtime/ortools:latest \
-python3 /app/main.py
+-v $(pwd):/app ghcr.io/nextmv-io/runtime/python:3.11 \
+sh -c 'pip install -r requirements.txt && python3 /app/main.py'
 ```
 
 You can also debug the application by running it in a Dev Container. This

--- a/shift-assignment-pyomo/README.md
+++ b/shift-assignment-pyomo/README.md
@@ -22,6 +22,9 @@ Follow these steps to run locally.
     pip3 install -r requirements.txt
     ```
 
+1. Further dependencies can be specified in the `requirements_extra.txt` file.
+   These dependencies will get bundled with the app on push.
+
 1. Run the command below to check that everything works as expected:
 
     ```bash

--- a/shift-assignment-pyomo/README.md
+++ b/shift-assignment-pyomo/README.md
@@ -41,7 +41,7 @@ Nextmv Cloud, you can use the following command:
 ```bash
 cat input.json | docker run -i --rm \
 -v $(pwd):/app ghcr.io/nextmv-io/runtime/pyomo:latest \
-python3 /app/main.py
+sh -c 'python3 /app/main.py'
 ```
 
 You can also debug the application by running it in a Dev Container. This

--- a/shift-assignment-pyomo/app.yaml
+++ b/shift-assignment-pyomo/app.yaml
@@ -5,3 +5,7 @@ runtime: ghcr.io/nextmv-io/runtime/pyomo:latest
 # (e.g.: configs/*.json) is supported.
 files:
   - main.py
+python:
+  # Packages the app depends on need to be listed in a requirements_extra.txt file
+  # that is referenced here. All listed packages will get bundled with the app.
+  pip-requirements: requirements_extra.txt

--- a/shift-assignment-pyomo/app.yaml
+++ b/shift-assignment-pyomo/app.yaml
@@ -1,11 +1,7 @@
 # This manifest holds the information the app needs to run on the Nextmv Cloud.
 type: python
-runtime: ghcr.io/nextmv-io/runtime/python:3.11
+runtime: ghcr.io/nextmv-io/runtime/pyomo:latest
 # List all files/directories that should be included in the app. Globbing
 # (e.g.: configs/*.json) is supported.
 files:
   - main.py
-python:
-  # Packages the app depends on need to be listed in a requirements.txt file
-  # that is referenced here. All listed packages will get bundled with the app.
-  pip-requirements: requirements.txt

--- a/shift-assignment-pyomo/requirements_extra.txt
+++ b/shift-assignment-pyomo/requirements_extra.txt
@@ -1,0 +1,4 @@
+# Extra requirements that will be bundled with the app.
+# These are in addition to the ones already installed in
+# the runtime image (the ones in the requirements.txt file).
+# sample-dependency==0.1.0

--- a/shift-planning-ortools/README.md
+++ b/shift-planning-ortools/README.md
@@ -13,10 +13,9 @@ The most important files created are `main.py` and `input.json`.
 
 Follow these steps to run locally.
 
-1. The packages listed in the `requirements.txt` file are available when using
-   the runtime specified in the `app.yaml` manifest. This runtime is used when
-   making remote runs. When working locally, make sure that all the required
-   packages are installed:
+1. The packages listed in the `requirements.txt` will get bundled with the app
+   as defined in the `app.yaml` manifest. When working locally, make sure that
+   these are installed as well:
 
     ```bash
     pip3 install -r requirements.txt

--- a/shift-planning-ortools/README.md
+++ b/shift-planning-ortools/README.md
@@ -41,7 +41,7 @@ Nextmv Cloud, you can use the following command:
 ```bash
 cat input.json | docker run -i --rm \
 -v $(pwd):/app ghcr.io/nextmv-io/runtime/python:3.11 \
-sh -c 'pip install -r requirements.txt && python3 /app/main.py'
+sh -c 'pip install -r requirements.txt > /dev/null && python3 /app/main.py'
 ```
 
 You can also debug the application by running it in a Dev Container. This

--- a/shift-planning-ortools/README.md
+++ b/shift-planning-ortools/README.md
@@ -40,8 +40,8 @@ Nextmv Cloud, you can use the following command:
 
 ```bash
 cat input.json | docker run -i --rm \
--v $(pwd):/app ghcr.io/nextmv-io/runtime/ortools:latest \
-python3 /app/main.py
+-v $(pwd):/app ghcr.io/nextmv-io/runtime/python:3.11 \
+sh -c 'pip install -r requirements.txt && python3 /app/main.py'
 ```
 
 You can also debug the application by running it in a Dev Container. This

--- a/shift-planning-pyomo/README.md
+++ b/shift-planning-pyomo/README.md
@@ -22,6 +22,9 @@ Follow these steps to run locally.
     pip3 install -r requirements.txt
     ```
 
+1. Further dependencies can be specified in the `requirements_extra.txt` file.
+   These dependencies will get bundled with the app on push.
+
 1. Run the command below to check that everything works as expected:
 
     ```bash

--- a/shift-planning-pyomo/README.md
+++ b/shift-planning-pyomo/README.md
@@ -41,7 +41,7 @@ Nextmv Cloud, you can use the following command:
 ```bash
 cat input.json | docker run -i --rm \
 -v $(pwd):/app ghcr.io/nextmv-io/runtime/pyomo:latest \
-python3 /app/main.py
+sh -c 'python3 /app/main.py'
 ```
 
 You can also debug the application by running it in a Dev Container. This

--- a/shift-planning-pyomo/app.yaml
+++ b/shift-planning-pyomo/app.yaml
@@ -1,8 +1,4 @@
 type: python
-runtime: ghcr.io/nextmv-io/runtime/python:3.11
+runtime: ghcr.io/nextmv-io/runtime/pyomo:latest
 files:
   - main.py
-python:
-  # Packages the app depends on need to be listed in a requirements.txt file
-  # that is referenced here. All listed packages will get bundled with the app.
-  pip-requirements: requirements.txt

--- a/shift-planning-pyomo/app.yaml
+++ b/shift-planning-pyomo/app.yaml
@@ -1,4 +1,11 @@
+# This manifest holds the information the app needs to run on the Nextmv Cloud.
 type: python
 runtime: ghcr.io/nextmv-io/runtime/pyomo:latest
+# List all files/directories that should be included in the app. Globbing
+# (e.g.: configs/*.json) is supported.
 files:
   - main.py
+python:
+  # Packages the app depends on need to be listed in a requirements_extra.txt file
+  # that is referenced here. All listed packages will get bundled with the app.
+  pip-requirements: requirements_extra.txt

--- a/shift-planning-pyomo/requirements_extra.txt
+++ b/shift-planning-pyomo/requirements_extra.txt
@@ -1,0 +1,4 @@
+# Extra requirements that will be bundled with the app.
+# These are in addition to the ones already installed in
+# the runtime image (the ones in the requirements.txt file).
+# sample-dependency==0.1.0

--- a/xpress/README.md
+++ b/xpress/README.md
@@ -21,10 +21,9 @@ The most important files created are `main.py` and `input.json`.
 
 Follow these steps to run locally.
 
-1. The packages listed in the `requirements.txt` file are available when using
-   the runtime specified in the `app.yaml` manifest. This runtime is used when
-   making remote runs. When working locally, make sure that all the required
-   packages are installed:
+1. The packages listed in the `requirements.txt` will get bundled with the app
+   as defined in the `app.yaml` manifest. When working locally, make sure that
+   these are installed as well:
 
     ```bash
     pip3 install -r requirements.txt

--- a/xpress/README.md
+++ b/xpress/README.md
@@ -48,8 +48,8 @@ Nextmv Cloud, you can use the following command:
 
 ```bash
 cat input.json | docker run -i --rm \
--v $(pwd):/app ghcr.io/nextmv-io/runtime/xpress:latest \
-python3 /app/main.py
+-v $(pwd):/app ghcr.io/nextmv-io/runtime/python:3.11 \
+sh -c 'pip install -r requirements.txt && python3 /app/main.py'
 ```
 
 You can also debug the application by running it in a Dev Container. This

--- a/xpress/README.md
+++ b/xpress/README.md
@@ -49,7 +49,7 @@ Nextmv Cloud, you can use the following command:
 ```bash
 cat input.json | docker run -i --rm \
 -v $(pwd):/app ghcr.io/nextmv-io/runtime/python:3.11 \
-sh -c 'pip install -r requirements.txt && python3 /app/main.py'
+sh -c 'pip install -r requirements.txt > /dev/null && python3 /app/main.py'
 ```
 
 You can also debug the application by running it in a Dev Container. This


### PR DESCRIPTION
# Description
Standardized Docker commands to use a new Python 3.11 runtime and included pip install steps for requirements across various README files.

# Changes
- Updated Docker commands to use `ghcr.io/nextmv-io/runtime/python:3.11` across all test snippets.
- Changed runtime in `app.yaml` files from generic runtime to `ghcr.io/nextmv-io/runtime/pyomo:latest` for cbc dependency.