### PR TITLE
Update nextroute to v1.6.2

### DIFF
--- a/.nextmv/golden/nextroute/inputs/input.json.golden
+++ b/.nextmv/golden/nextroute/inputs/input.json.golden
@@ -610,7 +610,7 @@
         "min_duration": 14135,
         "min_stops_in_vehicle": 9,
         "min_travel_duration": 11435,
-        "unplanned_stops": 3
+        "unplanned_stops": 7
       },
       "duration": 0.123,
       "value": 2059665.4384450912

--- a/nextroute/go.mod
+++ b/nextroute/go.mod
@@ -3,8 +3,8 @@ module example.com/your_project/nextroute
 go 1.22
 
 require (
-	github.com/nextmv-io/nextroute v1.5.0
-	github.com/nextmv-io/sdk v1.5.0
+	github.com/nextmv-io/nextroute v1.6.2
+	github.com/nextmv-io/sdk v1.6.0
 )
 
 require (

--- a/nextroute/go.sum
+++ b/nextroute/go.sum
@@ -301,10 +301,10 @@ github.com/modern-go/reflect2 v0.0.0-20180701023420-4b7aa43c6742/go.mod h1:bx2lN
 github.com/modern-go/reflect2 v1.0.1/go.mod h1:bx2lNnkwVCuqBIxFjflWJWanXIb3RllmbCylyMrvgv0=
 github.com/modern-go/reflect2 v1.0.2/go.mod h1:yWuevngMOJpCy52FWWMvUC8ws7m/LJsjYzDa0/r8luk=
 github.com/mwitkow/go-conntrack v0.0.0-20161129095857-cc309e4a2223/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=
-github.com/nextmv-io/nextroute v1.5.0 h1:KgMtFkXkVp3j8BdPagPQwjavBiWypdRfbacW7oXeqIg=
-github.com/nextmv-io/nextroute v1.5.0/go.mod h1:8XVDX1xpTJj5bFeJEMNxOy1GLwbMncwxALo0UhcLx54=
-github.com/nextmv-io/sdk v1.5.0 h1:sbaO/99qq7Yf1FeGZSmbbjWCum9gXE/vnT/fbsCzuf8=
-github.com/nextmv-io/sdk v1.5.0/go.mod h1:4kKTivuXdlx2ky+ZkBeUkTPIc8BTJ0PqKFYF3B+wCy4=
+github.com/nextmv-io/nextroute v1.6.2 h1:bWd9W6e4i+xE+Ksg64f7YqNweLPEGW2fTCD/d0S9L2Y=
+github.com/nextmv-io/nextroute v1.6.2/go.mod h1:1u1UQu+1y/DTwwc6DCRentyLhqDRD1lcOfy9t7wNFY0=
+github.com/nextmv-io/sdk v1.6.0 h1:WU9/znVN9XzXNUXWoQu9t6xZCHZ4AOaKBi4yqFVLLG0=
+github.com/nextmv-io/sdk v1.6.0/go.mod h1:4kKTivuXdlx2ky+ZkBeUkTPIc8BTJ0PqKFYF3B+wCy4=
 github.com/opentracing/opentracing-go v1.2.0/go.mod h1:GxEUsuufX4nBwe+T+Wl9TAgYrxe9dPLANfrWvHYVTgc=
 github.com/pascaldekloe/goe v0.0.0-20180627143212-57f6aae5913c/go.mod h1:lzWF7FIEvWOWxwDKqyGYQf6ZUaNfKdP144TG7ZOy1lc=
 github.com/pascaldekloe/goe v0.1.0/go.mod h1:lzWF7FIEvWOWxwDKqyGYQf6ZUaNfKdP144TG7ZOy1lc=


### PR DESCRIPTION
# Description
Upgraded _nextroute_ to `v1.6.2` to incorporate performance improvements.

# Changes
- Updated `github.com/nextmv-io/nextroute` to v1.6.2
- Updated `github.com/nextmv-io/sdk` to v1.6.0