### PR TITLE
Align shift assignment output format

### DIFF
--- a/.nextmv/golden/shift-assignment-ortools/inputs/input.json.golden
+++ b/.nextmv/golden/shift-assignment-ortools/inputs/input.json.golden
@@ -3,36 +3,37 @@
     {
       "assigned_shifts": [
         {
-          "end_time": "2023-11-20T22:00:00+02:00",
+          "end": "2023-11-20T22:00:00+02:00",
           "shift_id": "welder_monday-late",
-          "start_time": "2023-11-20T14:00:00+02:00",
+          "start": "2023-11-20T14:00:00+02:00",
           "worker_id": "Louis Hardy"
         },
         {
-          "end_time": "2023-11-20T14:00:00+02:00",
+          "end": "2023-11-20T14:00:00+02:00",
           "shift_id": "welder_monday-early",
-          "start_time": "2023-11-20T06:00:00+02:00",
+          "start": "2023-11-20T06:00:00+02:00",
           "worker_id": "Jacob Cunningham"
         },
         {
-          "end_time": "2023-11-20T14:00:00+02:00",
+          "end": "2023-11-20T14:00:00+02:00",
           "shift_id": "normal_monday-early",
-          "start_time": "2023-11-20T06:00:00+02:00",
+          "start": "2023-11-20T06:00:00+02:00",
           "worker_id": "Ray Heard"
         },
         {
-          "end_time": "2023-11-20T22:00:00+02:00",
+          "end": "2023-11-20T22:00:00+02:00",
           "shift_id": "normal_monday-late",
-          "start_time": "2023-11-20T14:00:00+02:00",
+          "start": "2023-11-20T14:00:00+02:00",
           "worker_id": "Mark Leath"
         },
         {
-          "end_time": "2023-11-20T14:00:00+02:00",
+          "end": "2023-11-20T14:00:00+02:00",
           "shift_id": "normal_monday-early",
-          "start_time": "2023-11-20T06:00:00+02:00",
+          "start": "2023-11-20T06:00:00+02:00",
           "worker_id": "Dylan Mccormack"
         }
-      ]
+      ],
+      "number_assigned_workers": 5
     }
   ],
   "statistics": {

--- a/.nextmv/golden/shift-assignment-pyomo/inputs/input.json.golden
+++ b/.nextmv/golden/shift-assignment-pyomo/inputs/input.json.golden
@@ -3,36 +3,37 @@
     {
       "assigned_shifts": [
         {
-          "end_time": "2023-11-20T22:00:00+02:00",
+          "end": "2023-11-20T22:00:00+02:00",
           "shift_id": "welder_monday-late",
-          "start_time": "2023-11-20T14:00:00+02:00",
+          "start": "2023-11-20T14:00:00+02:00",
           "worker_id": "Louis Hardy"
         },
         {
-          "end_time": "2023-11-20T14:00:00+02:00",
+          "end": "2023-11-20T14:00:00+02:00",
           "shift_id": "normal_monday-early",
-          "start_time": "2023-11-20T06:00:00+02:00",
+          "start": "2023-11-20T06:00:00+02:00",
           "worker_id": "Jacob Cunningham"
         },
         {
-          "end_time": "2023-11-20T14:00:00+02:00",
+          "end": "2023-11-20T14:00:00+02:00",
           "shift_id": "welder_monday-early",
-          "start_time": "2023-11-20T06:00:00+02:00",
+          "start": "2023-11-20T06:00:00+02:00",
           "worker_id": "Ray Heard"
         },
         {
-          "end_time": "2023-11-20T22:00:00+02:00",
+          "end": "2023-11-20T22:00:00+02:00",
           "shift_id": "normal_monday-late",
-          "start_time": "2023-11-20T14:00:00+02:00",
+          "start": "2023-11-20T14:00:00+02:00",
           "worker_id": "Mark Leath"
         },
         {
-          "end_time": "2023-11-20T14:00:00+02:00",
+          "end": "2023-11-20T14:00:00+02:00",
           "shift_id": "normal_monday-early",
-          "start_time": "2023-11-20T06:00:00+02:00",
+          "start": "2023-11-20T06:00:00+02:00",
           "worker_id": "Dylan Mccormack"
         }
-      ]
+      ],
+      "number_assigned_workers": 5
     }
   ],
   "statistics": {

--- a/shift-assignment-ortools/main.py
+++ b/shift-assignment-ortools/main.py
@@ -160,8 +160,8 @@ def solve(input_data: dict[str, Any], duration: int, provider: str) -> dict[str,
         schedule = {
             "assigned_shifts": [
                 {
-                    "start_time": s["start_time"],
-                    "end_time": s["end_time"],
+                    "start": s["start_time"],
+                    "end": s["end_time"],
                     "worker_id": e["id"],
                     "shift_id": s["id"],
                 }
@@ -170,7 +170,8 @@ def solve(input_data: dict[str, Any], duration: int, provider: str) -> dict[str,
                 if x_assign[(e["id"], s["id"])].solution_value() > 0.5
             ],
         }
-        active_workers = len({s["worker_id"] for s in schedule["assigned_shifts"]})
+        schedule["number_assigned_workers"] = len(schedule["assigned_shifts"])
+        active_workers = schedule["number_assigned_workers"]
         total_workers = len(workers)
 
     # Creates the statistics.

--- a/shift-assignment-pyomo/main.py
+++ b/shift-assignment-pyomo/main.py
@@ -176,8 +176,8 @@ def solve(input_data: dict[str, Any], duration: int, provider: str) -> dict[str,
         schedule = {
             "assigned_shifts": [
                 {
-                    "start_time": s["start_time"],
-                    "end_time": s["end_time"],
+                    "start": s["start_time"],
+                    "end": s["end_time"],
                     "worker_id": e["id"],
                     "shift_id": s["id"],
                 }
@@ -186,7 +186,8 @@ def solve(input_data: dict[str, Any], duration: int, provider: str) -> dict[str,
                 if model.x_assign[(e["id"], s["id"])].value > 0.5
             ],
         }
-        active_workers = len({s["worker_id"] for s in schedule["assigned_shifts"]})
+        schedule["number_assigned_workers"] = len(schedule["assigned_shifts"])
+        active_workers = schedule["number_assigned_workers"]
         total_workers = len(workers)
 
     # Creates the statistics.


### PR DESCRIPTION
# Description
This update aligns the shift assignment output format with visualization expectations.

## Changes
- Renamed `start_time` to `start` and `end_time` to `end` in assigned shifts output.
- Added `number_assigned_workers` to the schedule output for a direct count of assigned shifts.