### PR TITLE
Adds Slack notifications about releases, upgrades to nextmv-py v0.11.1

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -229,5 +229,6 @@ jobs:
             --apps "${{ env.APPS }}" \
             --bucket "${{ env.BUCKET }}" \
             --folder "${{ env.FOLDER }}" \
-            --manifest "${{ env.MANIFEST }}"
+            --manifest "${{ env.MANIFEST }}" \
+            --slack-url "${{ secrets.SLACK_URL_MISSION_CONTROL }}"
         working-directory: ./community-apps/.nextmv/release

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -225,10 +225,14 @@ jobs:
         if: ${{ env.APPS != '' }}
         run: |
           export PATH=$PATH:~/.nextmv # Make CLI available in non-interactive shell
+          export SLACK_NOTIFY_PARAM="" # Only notify slack for prod releases
+          if [ ${{ matrix.environment }} == "prod" ]; then
+            export SLACK_NOTIFY_PARAM="--slack-url \"${{ secrets.SLACK_URL_MISSION_CONTROL }}\""
+          fi
           python main.py \
             --apps "${{ env.APPS }}" \
             --bucket "${{ env.BUCKET }}" \
             --folder "${{ env.FOLDER }}" \
             --manifest "${{ env.MANIFEST }}" \
-            --slack-url "${{ secrets.SLACK_URL_MISSION_CONTROL }}"
+            $SLACK_NOTIFY_PARAM
         working-directory: ./community-apps/.nextmv/release

--- a/.nextmv/release/main.py
+++ b/.nextmv/release/main.py
@@ -4,6 +4,7 @@ import tarfile
 from datetime import datetime
 
 import nextmv
+import requests
 from boto3 import client as s3Client
 from log import log
 from manifest import Manifest
@@ -20,6 +21,7 @@ def main():
         nextmv.Parameter("bucket", str, description="S3 bucket.", required=True),
         nextmv.Parameter("folder", str, description="S3 bucket folder.", required=True),
         nextmv.Parameter("manifest", str, description="Manifest file.", required=True),
+        nextmv.Parameter("slack-url", str, description="Slack webhook URL.", default=None),
     )
 
     apps = [
@@ -83,6 +85,9 @@ def main():
             marketplace_version=new_marketplace_version,
             workflow_app=workflow_app,
         )
+
+        if options.slack_url is not None:
+            notify_slack(url=options.slack_url, app=name, version=new_app_version)
 
     manifest.upload(
         client=client,
@@ -239,6 +244,22 @@ def bump_marketplace_version(
         )
 
     return f"v{major}.{minor}.{patch}"
+
+
+def notify_slack(url: str, app: str, version: str, marketplace_version: str):
+    """
+    Notify Slack channel about release.
+    """
+
+    response = requests.post(
+        url,
+        json={
+            "text": f"Release notification - community-apps/{app} {version} / marketplace {marketplace_version}",
+        },
+    )
+
+    if response.status_code != 200:
+        log(f"Failed to send notification to Slack: {response.text}")
 
 
 if __name__ == "__main__":

--- a/.nextmv/release/main.py
+++ b/.nextmv/release/main.py
@@ -251,7 +251,7 @@ def bump_marketplace_version(
     return f"v{major}.{minor}.{patch}"
 
 
-def notify_slack(url: str, app: str, version: str, marketplace_version: str):
+def notify_slack(url: str, app: str, version: str, marketplace_version: str) -> None:
     """
     Notify Slack channel about release.
     """

--- a/.nextmv/release/main.py
+++ b/.nextmv/release/main.py
@@ -87,7 +87,12 @@ def main():
         )
 
         if options.slack_url is not None:
-            notify_slack(url=options.slack_url, app=name, version=new_app_version)
+            notify_slack(
+                url=options.slack_url,
+                app=name,
+                version=new_app_version,
+                marketplace_version=new_marketplace_version,
+            )
 
     manifest.upload(
         client=client,

--- a/.nextmv/release/requirements.txt
+++ b/.nextmv/release/requirements.txt
@@ -1,4 +1,5 @@
 boto3>=1.34.33
 pyyaml>=6.0.1
 ruff>=0.1.7
+requests>=2.26.0
 nextmv==v0.11.0

--- a/.nextmv/release/requirements.txt
+++ b/.nextmv/release/requirements.txt
@@ -2,4 +2,4 @@ boto3>=1.34.33
 pyyaml>=6.0.1
 ruff>=0.1.7
 requests>=2.26.0
-nextmv==v0.11.0
+nextmv==0.11.1

--- a/python-ampl-facilitylocation/requirements.txt
+++ b/python-ampl-facilitylocation/requirements.txt
@@ -17,5 +17,5 @@ ampl-module-open==20240121
 ampl-module-scip==20240121
 ampl-module-xpress==20240115
 
-nextmv==v0.11.0
+nextmv==0.11.1
 pandas==2.2.2

--- a/python-ampl-knapsack/requirements.txt
+++ b/python-ampl-knapsack/requirements.txt
@@ -17,5 +17,5 @@ ampl-module-open==20240121
 ampl-module-scip==20240121
 ampl-module-xpress==20240115
 
-nextmv==v0.11.0
+nextmv==0.11.1
 

--- a/python-ampl-priceoptimization/requirements.txt
+++ b/python-ampl-priceoptimization/requirements.txt
@@ -17,5 +17,5 @@ ampl-module-open==20240121
 ampl-module-scip==20240121
 ampl-module-xpress==20240115
 
-nextmv==v0.11.0
+nextmv==0.11.1
 

--- a/python-gurobi-knapsack/requirements.txt
+++ b/python-gurobi-knapsack/requirements.txt
@@ -1,3 +1,3 @@
 gurobipy==11.0.0
-nextmv==v0.11.0
+nextmv==0.11.1
 

--- a/python-hello-world/requirements.txt
+++ b/python-hello-world/requirements.txt
@@ -1,2 +1,2 @@
 # Define the packages required by your project here.
-nextmv==v0.11.0
+nextmv==0.11.1

--- a/python-highs-knapsack/requirements.txt
+++ b/python-highs-knapsack/requirements.txt
@@ -1,2 +1,2 @@
 highspy==1.7.2
-nextmv==v0.11.0
+nextmv==0.11.1

--- a/python-ortools-costflow/requirements.txt
+++ b/python-ortools-costflow/requirements.txt
@@ -1,2 +1,2 @@
 ortools==9.8.3296
-nextmv==v0.11.0
+nextmv==0.11.1

--- a/python-ortools-demandforecasting/requirements.txt
+++ b/python-ortools-demandforecasting/requirements.txt
@@ -1,2 +1,2 @@
 ortools==9.8.3296
-nextmv==v0.11.0
+nextmv==0.11.1

--- a/python-ortools-knapsack-multicsv/requirements.txt
+++ b/python-ortools-knapsack-multicsv/requirements.txt
@@ -1,2 +1,2 @@
 ortools==9.8.3296
-nextmv==v0.11.0
+nextmv==0.11.1

--- a/python-ortools-knapsack/requirements.txt
+++ b/python-ortools-knapsack/requirements.txt
@@ -1,2 +1,2 @@
 ortools==9.8.3296
-nextmv==v0.11.0
+nextmv==0.11.1

--- a/python-ortools-routing/requirements.txt
+++ b/python-ortools-routing/requirements.txt
@@ -1,2 +1,2 @@
 ortools==9.8.3296
-nextmv==v0.11.0
+nextmv==0.11.1

--- a/python-ortools-shiftassignment/requirements.txt
+++ b/python-ortools-shiftassignment/requirements.txt
@@ -1,2 +1,2 @@
 ortools==9.8.3296
-nextmv==v0.11.0
+nextmv==0.11.1

--- a/python-ortools-shiftplanning/requirements.txt
+++ b/python-ortools-shiftplanning/requirements.txt
@@ -1,2 +1,2 @@
 ortools==9.8.3296
-nextmv==v0.11.0
+nextmv==0.11.1

--- a/python-pyomo-knapsack/requirements.txt
+++ b/python-pyomo-knapsack/requirements.txt
@@ -1,2 +1,2 @@
 pyomo==6.7.2
-nextmv==v0.11.0
+nextmv==0.11.1

--- a/python-pyomo-shiftassignment/requirements.txt
+++ b/python-pyomo-shiftassignment/requirements.txt
@@ -1,2 +1,2 @@
 pyomo==6.7.2
-nextmv==v0.11.0
+nextmv==0.11.1

--- a/python-pyomo-shiftplanning/requirements.txt
+++ b/python-pyomo-shiftplanning/requirements.txt
@@ -1,2 +1,2 @@
 pyomo==6.7.2
-nextmv==v0.11.0
+nextmv==0.11.1

--- a/python-pyoptinterface-knapsack/requirements-arm64.txt
+++ b/python-pyoptinterface-knapsack/requirements-arm64.txt
@@ -4,4 +4,4 @@ highsbox==1.7.2.post2
 https://merschformann.github.io/random/content/wheels/pyoptinterface/pyoptinterface-0.2.8-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl
 
 # Other packages.
-nextmv==v0.11.0
+nextmv==0.11.1

--- a/python-pyoptinterface-knapsack/requirements.txt
+++ b/python-pyoptinterface-knapsack/requirements.txt
@@ -2,4 +2,4 @@
 pyoptinterface[highs]==0.2.8
 
 # Other packages.
-nextmv==v0.11.0
+nextmv==0.11.1

--- a/python-pyvroom-routing/requirements.txt
+++ b/python-pyvroom-routing/requirements.txt
@@ -1,2 +1,2 @@
 pyvroom==1.13.6
-nextmv==v0.11.0
+nextmv==0.11.1

--- a/python-xpress-knapsack/requirements.txt
+++ b/python-xpress-knapsack/requirements.txt
@@ -1,3 +1,3 @@
 xpress==9.4.2; platform_system != 'Darwin' or (platform_system == 'Darwin' and platform_machine != 'arm64')
-nextmv==v0.11.0
+nextmv==0.11.1
 


### PR DESCRIPTION
# Description

Added Slack notifications for improving internal transparency about ongoing releases.

## Changes

- Added _optional_ `--slack-url` parameter to release workflow command
- Added `notify_slack` function to send release notifications to Slack
- Included `requests>=2.26.0` in `requirements.txt` for HTTP requests to Slack Webhooks
- Upgrades to `nextmv-py==v0.11.1`