### PR TITLE
Update pyomo apps to support SCIP

### DIFF
--- a/python-pyomo-knapsack/main.py
+++ b/python-pyomo-knapsack/main.py
@@ -7,6 +7,7 @@ import pyomo.environ as pyo
 SUPPORTED_PROVIDER_DURATIONS = {
     "cbc": "sec",
     "glpk": "tmlim",
+    "scip": "limits/time",
 }
 
 
@@ -84,7 +85,7 @@ def solve(input: nextmv.Input, options: nextmv.Options) -> nextmv.Output:
     model.objective = pyo.Objective(expr=values, sense=pyo.maximize)
 
     # Solves the problem.
-    results = solver.solve(model)
+    results = solver.solve(model, tee=True)
 
     # Convert to solution format.
     value = pyo.value(model.objective, exception=False)

--- a/python-pyomo-knapsack/requirements.txt
+++ b/python-pyomo-knapsack/requirements.txt
@@ -1,2 +1,2 @@
-pyomo==6.7.2
+pyomo==6.8.0
 nextmv==0.12.0

--- a/python-pyomo-shiftassignment/requirements.txt
+++ b/python-pyomo-shiftassignment/requirements.txt
@@ -1,2 +1,2 @@
-pyomo==6.7.2
+pyomo==6.8.0
 nextmv==0.12.0

--- a/python-pyomo-shiftplanning/requirements.txt
+++ b/python-pyomo-shiftplanning/requirements.txt
@@ -1,2 +1,2 @@
-pyomo==6.7.2
+pyomo==6.8.0
 nextmv==0.12.0


### PR DESCRIPTION
# Description

- Adds new element to provider durations: `scip`
- Allows verbose mode and uses Nextmv SDK to capture logs to stderr.
- Changes the `python-pyomo-shiftplanning` app to match the other Pyomo apps (import just `pyomo` as `pyo` instead of the individual components)