### PR TITLE
Upgrades PyOptInterface to 0.4.0

### DIFF
--- a/.nextmv/golden/python-pyoptinterface-knapsack/inputs/input.json.golden
+++ b/.nextmv/golden/python-pyoptinterface-knapsack/inputs/input.json.golden
@@ -3,7 +3,7 @@
     "duration": 30,
     "input": "input.json",
     "output": "output.json",
-    "version": "0.2.8"
+    "version": "0.4.0"
   },
   "solution": {
     "items": [

--- a/python-pyoptinterface-knapsack/app.yaml
+++ b/python-pyoptinterface-knapsack/app.yaml
@@ -8,4 +8,4 @@ files:
 python:
   # Packages the app depends on need to be listed in a requirements.txt file
   # that is referenced here. All listed packages will get bundled with the app.
-  pip-requirements: requirements-arm64.txt
+  pip-requirements: requirements.txt

--- a/python-pyoptinterface-knapsack/requirements-arm64.txt
+++ b/python-pyoptinterface-knapsack/requirements-arm64.txt
@@ -1,7 +1,0 @@
-# pyoptinterface package with the Highs solver.
-# Note: until linux/aarch64 wheels are available on PyPI, the necessary wheel is hosted independently on GitHub.
-highsbox==1.7.2.post2
-https://merschformann.github.io/random/content/wheels/pyoptinterface/pyoptinterface-0.2.8-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl
-
-# Other packages.
-nextmv==0.15.1

--- a/python-pyoptinterface-knapsack/requirements.txt
+++ b/python-pyoptinterface-knapsack/requirements.txt
@@ -1,5 +1,5 @@
 # pyoptinterface package with the Highs solver.
-pyoptinterface[highs]==0.2.8
+pyoptinterface[highs]==0.4.0
 
 # Other packages.
 nextmv==0.15.1


### PR DESCRIPTION
# Description

Upgrades PyOptInterface to `0.4.0`. This includes added support for linux/arm64 rendering the self-hosted wheels workaround unnecessary.

## Changes

- Deleted workaround `requirements-arm64.txt`.
- Updated PyOptInterface version from `0.2.8` to `0.4.0`.