### PR TITLE
Runs readme tests on push

### DIFF
--- a/.github/workflows/readme-test.yml
+++ b/.github/workflows/readme-test.yml
@@ -1,9 +1,6 @@
 # The readme-test workflow runs all commands contained in the README files of the apps.
 name: readme-test
-on:
-  workflow_dispatch:
-  pull_request:
-    types: [opened, ready_for_review]
+on: [push, workflow_dispatch]
 jobs:
   readme-test:
     runs-on: ubuntu-latest

--- a/.nextmv/readme/README.md
+++ b/.nextmv/readme/README.md
@@ -18,8 +18,15 @@ in the `workflow-configuration.yml` file.
 Update the expectations / re-run the tests:
 
 ```bash
-go test ./... --update
+go test -v ./... --update
 ```
 
 Add any special handling for certain commands (e.g.: do not test their output /
 silence them) to the `workflow-configuration.yml` file.
+
+Run only a specific test and update its expectations (here: `go-hello-world` app
+and its first README command):
+
+```bash
+go test -v -run TestGolden/go-hello-world/0.sh -update ./...
+```


### PR DESCRIPTION
# Description

This PR makes the README tests run on every push instead of only on (re-)opened PRs. This should be acceptable now that many apps area already released and work shifted to less frequent updates.

## Changes

* Changed README test workflow to run on every push.