### PR TITLE
Improves docs of Gurobi and Hexaly apps

### DIFF
--- a/java-gurobi-knapsack/README.md
+++ b/java-gurobi-knapsack/README.md
@@ -12,8 +12,8 @@ Gurobi solver. We solve a knapsack Mixed Integer Programming problem.
         done via [console].
         - Define a file secret with the name `gurobi.lic` and the content of
           your license file.
-        - Define a env variable secret with the name `GRB_LICENSE_FILE` and
-          the value `./gurobi.lic` to point Gurobi to the license file.
+        - Define an environment variable secret with the name `GRB_LICENSE_FILE`
+          and the value `./gurobi.lic` to point Gurobi to the license file.
 1. Generate a `main.jar`.
 
     ```bash

--- a/java-gurobi-knapsack/README.md
+++ b/java-gurobi-knapsack/README.md
@@ -10,6 +10,10 @@ Gurobi solver. We solve a knapsack Mixed Integer Programming problem.
     1. **Platform**: Don't forget to also define the license file as a
         [secret][secret] in your Nextmv Application as well. This can be easily
         done via [console].
+        - Define a file secret with the name `gurobi.lic` and the content of
+          your license file.
+        - Define a env variable secret with the name `GRB_LICENSE_FILE` and
+          the value `./gurobi.lic` to point Gurobi to the license file.
 1. Generate a `main.jar`.
 
     ```bash

--- a/java-hexaly-knapsack/README.md
+++ b/java-hexaly-knapsack/README.md
@@ -10,6 +10,10 @@ Hexaly solver. We solve a knapsack Mixed Integer Programming problem.
     1. **Platform**: Don't forget to also define the license file as a
         [secret][secret] in your Nextmv Application as well. This can be easily
         done via [console].
+        - Define a file secret with the name `license.dat` and the content of
+          your license file.
+        - Define a env variable secret with the name `LD_LIBRARY_PATH` and
+          the value `./lib` to point Hexaly to the bundled `*.so` libraries.
 1. Since there is no Hexaly Maven package, we need to setup a local one. For
     this, copy the following files into the project:
     - `hexaly.jar` -> `./lib/`

--- a/java-hexaly-knapsack/README.md
+++ b/java-hexaly-knapsack/README.md
@@ -12,8 +12,8 @@ Hexaly solver. We solve a knapsack Mixed Integer Programming problem.
         done via [console].
         - Define a file secret with the name `license.dat` and the content of
           your license file.
-        - Define a env variable secret with the name `LD_LIBRARY_PATH` and
-          the value `./lib` to point Hexaly to the bundled `*.so` libraries.
+        - Define an environment variable secret with the name `LD_LIBRARY_PATH`
+          and the value `./lib` to point Hexaly to the bundled `*.so` libraries.
 1. Since there is no Hexaly Maven package, we need to setup a local one. For
     this, copy the following files into the project:
     - `hexaly.jar` -> `./lib/`

--- a/python-wf-ortools-region-allocation/README.md
+++ b/python-wf-ortools-region-allocation/README.md
@@ -1,4 +1,4 @@
-# Nextmv Tracked Runs for OR-Tools Region Allocation
+# Nextmv Workflow for generating visual assets for the Region Allocation app
 
 This example shows how to wrap the Region Allocation app in a meta-app using
 workflows in order to add additional visual assets to its runs.


### PR DESCRIPTION
# Description

This PR is a small improvement to the Java Gurobi and Hexaly apps to ease setting them up in Nextmv platform.

## Changes

- Noted the exact secrets to define for running `java-gurobi-knapsack` and `java-hexaly-knapsack`.
- Fixes copy/paste issue in readme header of `python-wf-ortools-region-allocation`.

Resolves ENG-6122