### PR TITLE
Adds python custom visuals app to cloneable apps

### DIFF
--- a/.nextmv/workflow-configuration.yml
+++ b/.nextmv/workflow-configuration.yml
@@ -209,6 +209,12 @@ apps:
     marketplace_app_id:
     marketplace_major_version:
     description: Use tracked runs in Python - region allocation.
+  - name: python-wf-custom-visuals
+    type: python
+    app_id:
+    marketplace_app_id:
+    marketplace_major_version:
+    description: Use workflows in Python - custom visuals.
   - name: python-wf-ortools-region-allocation
     type: python
     app_id:


### PR DESCRIPTION
# Description

Adds missing entry for `python-wf-custom-visuals` app in list of apps so that it can be cloned via CLI.

## Changes

- Adds `python-wf-custom-visuals` to list of cloneable apps.