### PR TITLE
(Re-)activates verbose hexaly mode by default

### DIFF
--- a/java-hexaly-knapsack/src/main/java/com/nextmv/example/Main.java
+++ b/java-hexaly-knapsack/src/main/java/com/nextmv/example/Main.java
@@ -13,6 +13,10 @@ public final class Main {
     System.setOut(System.err);
 
     try (HexalyOptimizer optimizer = new HexalyOptimizer()) {
+      // Now that stdout is redirected, we can safely activate logging
+      // (may have been deactivated by license file parameters).
+      optimizer.getParam().setVerbosity(1);
+      
       // Parse arguments and load input as before
       Options options = Options.fromArguments(args);
       Input input = Input.fromString(options.getInputPath());


### PR DESCRIPTION
# Description

Activates verbose _Hexaly_ output mode by default. This is useful if users need to deactivate their output temporarily for Hexaly to initialize silently. I.e., when users specify this in their license file:

```txt
[DEFAULT_PARAMETERS]
verbosity = 0
```

This change makes sure that we still see the logs when using above method to keep stdout clean from logs (we only want to log to stderr which cannot be redirected for Hexaly Cloud activation - we need to silence [temporarily] instead).

## Changes

- (Re-)activate Hexaly log output by default.