### PR TITLE
Lists python multiexcel example

### DIFF
--- a/.nextmv/workflow-configuration.yml
+++ b/.nextmv/workflow-configuration.yml
@@ -161,6 +161,12 @@ apps:
     marketplace_app_id:
     marketplace_major_version:
     description: Use Python and OR-Tools - multi CSV knapsack.
+  - name: python-ortools-multiknapsack-multiexcel
+    type: python
+    app_id:
+    marketplace_app_id:
+    marketplace_major_version:
+    description: Use Python and OR-Tools - multi knapsack via Excel.
   - name: python-ortools-region-allocation
     type: python
     app_id:


### PR DESCRIPTION
# Description

Lists the `python-ortools-multiknapsack-multiexcel` app in the workflow config so that it can be cloned via Nextmv CLI.

## Changes

- Lists `python-ortools-multiknapsack-multiexcel` in workflow config.