### PR TITLE
Fixes SCIP knapsack not being marketplace

### DIFF
--- a/.nextmv/workflow-configuration.yml
+++ b/.nextmv/workflow-configuration.yml
@@ -223,9 +223,9 @@ apps:
     description: Use Python and Pyvroom - VRP.
   - name: python-scip-knapsack
     type: python
-    app_id: knapsack-scip
-    marketplace_app_id: knapsack.scip
-    marketplace_major_version: v1
+    app_id:
+    marketplace_app_id:
+    marketplace_major_version:
     description: Use Python and SCIP - knapsack.
   - name: python-tr-ortools-region-allocation
     type: python


### PR DESCRIPTION
# Description

Fixes `python-scip-knapsack` not being a marketplace app by avoiding to release it as such.

## Changes

- Fixes `python-scip-knapsack` not being a marketplace app.