### PR TITLE
Changes workflow triggers to allow runs on external PRs

### DIFF
--- a/.github/workflows/go-lint.yml
+++ b/.github/workflows/go-lint.yml
@@ -1,5 +1,8 @@
 name: go lint
-on: [push]
+on:
+  push:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
 jobs:
   community-apps-go-lint:
     runs-on: ubuntu-latest

--- a/.github/workflows/golden.yml
+++ b/.github/workflows/golden.yml
@@ -1,5 +1,9 @@
 name: golden
-on: [push, workflow_dispatch]
+on:
+  push:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+  workflow_dispatch:
 jobs:
   create-matrix:
     runs-on: ubuntu-latest

--- a/.github/workflows/json-lint.yml
+++ b/.github/workflows/json-lint.yml
@@ -1,5 +1,8 @@
 name: json lint
-on: [push]
+on:
+  push:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
 jobs:
   community-apps-json-lint:
     runs-on: ubuntu-latest

--- a/.github/workflows/markdown-lint.yml
+++ b/.github/workflows/markdown-lint.yml
@@ -1,5 +1,8 @@
 name: markdown lint
-on: [push]
+on:
+  push:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
 jobs:
   community-apps-markdown-lint:
     runs-on: ubuntu-latest

--- a/.github/workflows/python-lint.yml
+++ b/.github/workflows/python-lint.yml
@@ -1,5 +1,8 @@
 name: python lint
-on: [push]
+on:
+  push:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
 jobs:
   community-apps-python-lint:
     runs-on: ubuntu-latest

--- a/.github/workflows/readme-test.yml
+++ b/.github/workflows/readme-test.yml
@@ -1,6 +1,10 @@
 # The readme-test workflow runs all commands contained in the README files of the apps.
 name: readme-test
-on: [push, workflow_dispatch]
+on:
+  push:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+  workflow_dispatch:
 jobs:
   readme-test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
# Description

Allows workflows to get triggered by external PRs. This makes external contributions much easier. They didn't get triggered by these before, since they do not count as a 'push' to our repository.

## Changes

- Allow workflows to also be triggered by external PRs.