### PR TITLE
Fixes order fulfillment output

### DIFF
--- a/go-highs-orderfulfillment/main.go
+++ b/go-highs-orderfulfillment/main.go
@@ -723,7 +723,7 @@ func format(
 			}
 		}
 
-		o.Solutions = append(o.Solutions, oflSolution)
+		o.Solutions = []any{oflSolution}
 
 		customResultStatistics := customResultStatistics{
 			DeliveryCosts: round(totalDeliveryCosts),

--- a/python-gurobi-knapsack/requirements.txt
+++ b/python-gurobi-knapsack/requirements.txt
@@ -1,2 +1,2 @@
-gurobipy==11.0.0
+gurobipy==13.0.0
 nextmv==0.35.1


### PR DESCRIPTION
# Description

Fixes order fulfillment output containing an empty solution.

## Changes

- Fixes `go-highs-orderfulfillment` output containing an empty solution in first position.