### PR TITLE
Aligns pyomo dependency with SCIP of runtime image

### DIFF
--- a/python-pyomo-knapsack/requirements.txt
+++ b/python-pyomo-knapsack/requirements.txt
@@ -1,2 +1,2 @@
-pyomo==6.8.0
+pyomo==6.9.5
 nextmv==0.39.0

--- a/python-pyomo-shiftassignment/requirements.txt
+++ b/python-pyomo-shiftassignment/requirements.txt
@@ -1,2 +1,2 @@
-pyomo==6.8.0
+pyomo==6.9.5
 nextmv==0.39.0

--- a/python-pyomo-shiftplanning/requirements.txt
+++ b/python-pyomo-shiftplanning/requirements.txt
@@ -1,2 +1,2 @@
-pyomo==6.8.0
+pyomo==6.9.5
 nextmv==0.39.0


### PR DESCRIPTION
# Description

Aligns the *pyomo* dependency to work with the SCIP version used in the runtime image.

## Changes

- Bumps `pyomo` dependency to `6.9.5`.