### PR TITLE
Adds sardine-can app to workflow config

### DIFF
--- a/.nextmv/workflow-configuration.yml
+++ b/.nextmv/workflow-configuration.yml
@@ -1,4 +1,10 @@
 apps:
+  - name: cs-sardinecan-packing
+    type: binary
+    app_id:
+    marketplace_app_id:
+    marketplace_major_version:
+    description: Use C# and SardineCan - packing.
   - name: cpp-hello-world
     type: binary
     app_id:


### PR DESCRIPTION
# Description

Adds the `cs-sardinecan-packing` app to the workflow configuration. This will make the app cloneable.