### PR TITLE
Makes sure old CLI is used for release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -215,7 +215,7 @@ jobs:
       - name: Set up Nextmv CLI
         if: ${{ env.APPS != '' }}
         run: |
-          export PATH=$PATH:~/.nextmv # Make CLI available in non-interactive shell
+          export PATH=~/.nextmv:$PATH # Make CLI available in non-interactive shell
           nextmv configure \
             --api-key $MARKETPLACE_API_KEY \
             -e $API_ENDPOINT
@@ -224,7 +224,7 @@ jobs:
       - name: Release the apps
         if: ${{ env.APPS != '' }}
         run: |
-          export PATH=$PATH:~/.nextmv # Make CLI available in non-interactive shell
+          export PATH=~/.nextmv:$PATH # Make CLI available in non-interactive shell
           export SLACK_NOTIFY_PARAM="" # Only notify slack for prod releases
           if [ ${{ matrix.environment }} == "prod" ]; then
             export SLACK_NOTIFY_PARAM="--slack-url ${{ secrets.SLACK_URL_MISSION_CONTROL }}"


### PR DESCRIPTION
# Description

Makes sure the old (Go) CLI is used in the release workflow. This is a temporary measure until we fully move to the new CLI.

## Changes

- Changes precedence of `$PATH` to prefer old (Go) CLI for release workflow.