### PR TITLE
Uses local only for I/O options

### DIFF
--- a/.nextmv/readme/python-ortools-region-allocation/2.sh
+++ b/.nextmv/readme/python-ortools-region-allocation/2.sh
@@ -1,3 +1,3 @@
 cat input.json | docker run -i --rm \
--v $(pwd):/app ghcr.io/nextmv-io/runtime/pyomo:latest \
+-v $(pwd):/app ghcr.io/nextmv-io/runtime/python:3.11 \
 sh -c 'python3 /app/main.py'

--- a/go-nextroute/app.yaml
+++ b/go-nextroute/app.yaml
@@ -290,21 +290,11 @@ configuration:
       - name: runner.input.path
         option_type: string
         description: The input file path
-        ui:
-          control_type: input
-          display_name: Input Path
-          hidden_from:
-            - viewer
-            - operator
+        local_only: true
       - name: runner.output.path
         option_type: string
         description: The output file path
-        ui:
-          control_type: input
-          display_name: Output Path
-          hidden_from:
-            - viewer
-            - operator
+        local_only: true
       - name: runner.output.solutions
         option_type: string
         description: "{all, last} specifies whether to output all solutions or only the last one"
@@ -321,21 +311,11 @@ configuration:
       - name: runner.profile.cpu
         option_type: string
         description: The CPU profile file path
-        ui:
-          control_type: input
-          display_name: CPU Profile Path
-          hidden_from:
-            - viewer
-            - operator
+        local_only: true
       - name: runner.profile.memory
         option_type: string
         description: The memory profile file path
-        ui:
-          control_type: input
-          display_name: Memory Profile Path
-          hidden_from:
-            - viewer
-            - operator
+        local_only: true
 
       # Solve options
       - name: solve.duration

--- a/python-ortools-region-allocation/README.md
+++ b/python-ortools-region-allocation/README.md
@@ -28,7 +28,7 @@ Cloud, you can use the following command:
 
 ```bash
 cat input.json | docker run -i --rm \
--v $(pwd):/app ghcr.io/nextmv-io/runtime/pyomo:latest \
+-v $(pwd):/app ghcr.io/nextmv-io/runtime/python:3.11 \
 sh -c 'python3 /app/main.py'
 ```
 

--- a/python-simpy-carwash-simulation/app.yaml
+++ b/python-simpy-carwash-simulation/app.yaml
@@ -36,15 +36,9 @@ configuration:
         description: Path to input data file, default is stdin.
         option_type: string
         default: ""
-        required: false
-        ui:
-          control_type: input
-          display_name: Input Path
+        local_only: true
       - name: output
         description: Path to output data file, default is stdout.
         option_type: string
         default: ""
-        required: false
-        ui:
-          control_type: input
-          display_name: Output Path
+        local_only: true

--- a/python-xpress-park-location/app.yaml
+++ b/python-xpress-park-location/app.yaml
@@ -22,21 +22,13 @@ configuration:
         default: ""
         required: false
         description: Path to input file. Default is stdin.
-        ui:
-          control_type: input
-          hidden_from:
-            - operator
-          display_name: Input file
+        local_only: true
       - name: output
         option_type: string
         default: ""
         required: false
         description: Path to output file. Default is stdout.
-        ui:
-          control_type: input
-          hidden_from:
-            - operator
-          display_name: Output file
+        local_only: true
       - name: objective
         option_type: string
         default: average_distance


### PR DESCRIPTION
# Description

Uses the `local_only: true` flag for input/output options defined in app manifests. These options are only useful when running the app locally, so, we do not want to consider them when pushing to Nextmv Plaform.

## Changes

- Adds `local_only: true` flag for I/O options on relevant apps.