### PR TITLE
Bumps ortools dependency to latest

### DIFF
--- a/python-ortools-costflow/requirements.txt
+++ b/python-ortools-costflow/requirements.txt
@@ -1,2 +1,2 @@
-ortools==9.12.4544
+ortools==9.15.6755
 nextmv==1.6.2

--- a/python-ortools-demandforecasting/requirements.txt
+++ b/python-ortools-demandforecasting/requirements.txt
@@ -1,2 +1,2 @@
-ortools==9.12.4544
+ortools==9.15.6755
 nextmv==1.6.2

--- a/python-ortools-knapsack-multicsv/requirements.txt
+++ b/python-ortools-knapsack-multicsv/requirements.txt
@@ -1,2 +1,2 @@
-ortools==9.12.4544
+ortools==9.15.6755
 nextmv==1.6.2

--- a/python-ortools-knapsack/requirements.txt
+++ b/python-ortools-knapsack/requirements.txt
@@ -1,2 +1,2 @@
-ortools==9.12.4544
+ortools==9.15.6755
 nextmv==1.6.2

--- a/python-ortools-region-allocation/requirements.txt
+++ b/python-ortools-region-allocation/requirements.txt
@@ -1,2 +1,2 @@
-ortools==9.12.4544
+ortools==9.15.6755
 nextmv==1.6.2

--- a/python-ortools-routing/requirements.txt
+++ b/python-ortools-routing/requirements.txt
@@ -1,2 +1,2 @@
-ortools==9.12.4544
+ortools==9.15.6755
 nextmv==1.6.2

--- a/python-ortools-shiftassignment/requirements.txt
+++ b/python-ortools-shiftassignment/requirements.txt
@@ -1,2 +1,2 @@
-ortools==9.12.4544
+ortools==9.15.6755
 nextmv==1.6.2

--- a/python-ortools-shiftplanning/requirements.txt
+++ b/python-ortools-shiftplanning/requirements.txt
@@ -1,2 +1,2 @@
-ortools==9.12.4544
+ortools==9.15.6755
 nextmv==1.6.2

--- a/python-tr-ortools-region-allocation/requirements.txt
+++ b/python-tr-ortools-region-allocation/requirements.txt
@@ -1,2 +1,2 @@
-ortools==9.12.4544
+ortools==9.15.6755
 nextmv==1.6.2


### PR DESCRIPTION
# Description

Bumps the ortools dependency of relevant apps to its latest version. This also fix an issue on Windows where the dll loader writes to stdout, which might mess with the json output of the app.

## Changes

- Bumps ortools to its most recent version.